### PR TITLE
Gci 1451 create chprd records add reordered column

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chd/order/api/model/OrderHeader.java
+++ b/src/main/java/uk/gov/companieshouse/chd/order/api/model/OrderHeader.java
@@ -31,6 +31,9 @@ public class OrderHeader {
     @Column(name = "PAYMENTMETHOD")
     private long paymentMethod;
     @Basic
+    @Column(name = "REORDERED")
+    private long reordered;
+    @Basic
     @Column(name = "NUMORDERLINES")
     private long numOrderLines;
     @Basic
@@ -83,6 +86,12 @@ public class OrderHeader {
     }
 
     public void setPaymentMethod(long paymentMethod) { this.paymentMethod = paymentMethod; }
+
+    public long getReordered() {
+        return reordered;
+    }
+
+    public void setReordered(long reordered) { this.reordered = reordered; }
 
     public long getNumOrderLines() {
         return numOrderLines;

--- a/src/main/java/uk/gov/companieshouse/chd/order/api/service/OrderService.java
+++ b/src/main/java/uk/gov/companieshouse/chd/order/api/service/OrderService.java
@@ -25,6 +25,7 @@ public class OrderService {
     private static final long NUM_ORDER_LINES = 1;
     private static final long CUSTOMER_VERSION = 1;
     private static final String PRODUCT_SUB_KEY = "SCUD";
+    private static final long REORDERED = 0;
     @Value("${chprd.customer-id}")
     private long customerId;
     @Value("${chprd.payment-method}")
@@ -71,6 +72,7 @@ public class OrderService {
         orderHeader.setPsNumber(midRequest.getId());
         orderHeader.setOrderValue(Long.parseLong(midRequest.getItemCost()));
         orderHeader.setPaymentMethod(paymentMethod);
+        orderHeader.setReordered(REORDERED);
         orderHeader.setHandCsr(handcsr);
         orderHeader.setLanguage(language);
         orderHeader.setFlags(flags);

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceIntegrationTest.java
@@ -77,6 +77,8 @@ public class OrderServiceIntegrationTest {
     @Value("${chprd.delivery-location}")
     private long deliveryLocation;
     private static final String SUBKEY = "SCUD";
+    private static final long REORDERED = 0;
+    private static final long NUM_ORDER_LINES = 1;
 
     @Test
     public void saveOrderDetailsPersistsOrderHeaderSuccessfully(){
@@ -103,6 +105,8 @@ public class OrderServiceIntegrationTest {
         assertThat(orderHeader.getFlags(), is(flags));
         assertThat(orderHeader.getOrderValue(), is(Long.parseLong(ITEM_COST)));
         assertThat(orderHeader.getPaymentMethod(), is(paymentMethod));
+        assertThat(orderHeader.getReordered(), is(REORDERED));
+        assertThat(orderHeader.getNumOrderLines(), is(NUM_ORDER_LINES));
         assertThat(orderHeader.getPsNumber(), is(ID));
         assertThat(orderDetails.getCompanyName(), is(COMPANY_NAME));
         assertThat(orderDetails.getCompanyNumber(), is(COMPANY_NUMBER));


### PR DESCRIPTION
Adds support for `REORDERED` column in `ORDERHEADER` table.