### PR TITLE
Gci 1598 add identity id and barcode

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chd/order/api/dto/MissingImageDeliveriesDTO.java
+++ b/src/main/java/uk/gov/companieshouse/chd/order/api/dto/MissingImageDeliveriesDTO.java
@@ -37,6 +37,12 @@ public class MissingImageDeliveriesDTO {
     @JsonProperty("filing_history_date")
     private String filingHistoryDate;
 
+    @JsonProperty("filing_history_barcode")
+    private String filingHistoryBarcode;
+
+    @JsonProperty("entity_id")
+    private String entityID;
+
     @JsonProperty("item_cost")
     private String itemCost;
 
@@ -110,6 +116,22 @@ public class MissingImageDeliveriesDTO {
 
     public void setFilingHistoryDate(String filingHistoryDate) {
         this.filingHistoryDate = filingHistoryDate;
+    }
+
+    public String getFilingHistoryBarcode() {
+        return filingHistoryBarcode;
+    }
+
+    public void setFilingHistoryBarcode(String filingHistoryBarcode) {
+        this.filingHistoryBarcode = filingHistoryBarcode;
+    }
+
+    public String getEntityID() {
+        return entityID;
+    }
+
+    public void setEntityID(String entityID) {
+        this.entityID = entityID;
     }
 
     public String getItemCost() {

--- a/src/main/java/uk/gov/companieshouse/chd/order/api/exception/OrderServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/chd/order/api/exception/OrderServiceException.java
@@ -6,7 +6,7 @@ package uk.gov.companieshouse.chd.order.api.exception;
 public class OrderServiceException extends RuntimeException {
 
 	public OrderServiceException(String message) {
-		super(message);
+        super(message);
 	}
 
 }

--- a/src/main/java/uk/gov/companieshouse/chd/order/api/model/MissingImageDeliveriesRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chd/order/api/model/MissingImageDeliveriesRequest.java
@@ -13,6 +13,8 @@ public class MissingImageDeliveriesRequest {
 	private String filingHistoryType;
 	private String filingHistoryDescription;
 	private String filingHistoryDate;
+	private String filingHistoryBarcode;
+	private String entityID;
 	private String itemCost;
 
 	public String getId() {
@@ -83,6 +85,22 @@ public class MissingImageDeliveriesRequest {
 
 	public void setFilingHistoryDate(String filingHistoryDate) {
 		this.filingHistoryDate = filingHistoryDate;
+	}
+
+	public String getFilingHistoryBarcode() {
+		return filingHistoryBarcode;
+	}
+
+	public void setFilingHistoryBarcode(String filingHistoryBarcode) {
+		this.filingHistoryBarcode = filingHistoryBarcode;
+	}
+
+	public String getEntityID() {
+		return entityID;
+	}
+
+	public void setEntityID(String entityID) {
+		this.entityID = entityID;
 	}
 
 	public String getItemCost() {

--- a/src/main/java/uk/gov/companieshouse/chd/order/api/model/MissingImageDeliveriesRequest.java
+++ b/src/main/java/uk/gov/companieshouse/chd/order/api/model/MissingImageDeliveriesRequest.java
@@ -4,110 +4,110 @@ import java.time.LocalDateTime;
 
 public class MissingImageDeliveriesRequest {
 
-	private String id;
-	private String companyName;
-	private String companyNumber;
-	private LocalDateTime orderedAt;
-	private String paymentReference;
-	private String filingHistoryCategory;
-	private String filingHistoryType;
-	private String filingHistoryDescription;
-	private String filingHistoryDate;
-	private String filingHistoryBarcode;
-	private String entityID;
-	private String itemCost;
+    private String id;
+    private String companyName;
+    private String companyNumber;
+    private LocalDateTime orderedAt;
+    private String paymentReference;
+    private String filingHistoryCategory;
+    private String filingHistoryType;
+    private String filingHistoryDescription;
+    private String filingHistoryDate;
+    private String filingHistoryBarcode;
+    private String entityID;
+    private String itemCost;
 
-	public String getId() {
-		return id;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public void setId(String id) {
-		this.id = id;
-	}
+    public void setId(String id) {
+        this.id = id;
+    }
 
-	public String getCompanyName() {
-		return companyName;
-	}
+    public String getCompanyName() {
+        return companyName;
+    }
 
-	public void setCompanyName(String companyName) {
-		this.companyName = companyName;
-	}
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
 
-	public String getCompanyNumber() {
-		return companyNumber;
-	}
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
 
-	public void setCompanyNumber(String companyNumber) {
-		this.companyNumber = companyNumber;
-	}
+    public void setCompanyNumber(String companyNumber) {
+        this.companyNumber = companyNumber;
+    }
 
-	public LocalDateTime getOrderedAt() {
-		return orderedAt;
-	}
+    public LocalDateTime getOrderedAt() {
+        return orderedAt;
+    }
 
-	public void setOrderedAt(LocalDateTime orderedAt) {
-		this.orderedAt = orderedAt;
-	}
+    public void setOrderedAt(LocalDateTime orderedAt) {
+        this.orderedAt = orderedAt;
+    }
 
-	public String getPaymentReference() {
-		return paymentReference;
-	}
+    public String getPaymentReference() {
+        return paymentReference;
+    }
 
-	public void setPaymentReference(String paymentReference) {
-		this.paymentReference = paymentReference;
-	}
+    public void setPaymentReference(String paymentReference) {
+        this.paymentReference = paymentReference;
+    }
 
-	public String getFilingHistoryCategory() {
-		return filingHistoryCategory;
-	}
+    public String getFilingHistoryCategory() {
+        return filingHistoryCategory;
+    }
 
-	public void setFilingHistoryCategory(String filingHistoryCategory) {
-		this.filingHistoryCategory = filingHistoryCategory;
-	}
+    public void setFilingHistoryCategory(String filingHistoryCategory) {
+        this.filingHistoryCategory = filingHistoryCategory;
+    }
 
-	public String getFilingHistoryType() {
-		return filingHistoryType;
-	}
+    public String getFilingHistoryType() {
+        return filingHistoryType;
+    }
 
-	public void setFilingHistoryType(String filingHistoryType) { this.filingHistoryType = filingHistoryType; }
+    public void setFilingHistoryType(String filingHistoryType) { this.filingHistoryType = filingHistoryType; }
 
-	public String getFilingHistoryDescription() {
-		return filingHistoryDescription;
-	}
+    public String getFilingHistoryDescription() {
+        return filingHistoryDescription;
+    }
 
-	public void setFilingHistoryDescription(String filingHistoryDescription) {
-		this.filingHistoryDescription = filingHistoryDescription;
-	}
+    public void setFilingHistoryDescription(String filingHistoryDescription) {
+        this.filingHistoryDescription = filingHistoryDescription;
+    }
 
-	public String getFilingHistoryDate() {
-		return filingHistoryDate;
-	}
+    public String getFilingHistoryDate() {
+        return filingHistoryDate;
+    }
 
-	public void setFilingHistoryDate(String filingHistoryDate) {
-		this.filingHistoryDate = filingHistoryDate;
-	}
+    public void setFilingHistoryDate(String filingHistoryDate) {
+        this.filingHistoryDate = filingHistoryDate;
+    }
 
-	public String getFilingHistoryBarcode() {
-		return filingHistoryBarcode;
-	}
+    public String getFilingHistoryBarcode() {
+        return filingHistoryBarcode;
+    }
 
-	public void setFilingHistoryBarcode(String filingHistoryBarcode) {
-		this.filingHistoryBarcode = filingHistoryBarcode;
-	}
+    public void setFilingHistoryBarcode(String filingHistoryBarcode) {
+        this.filingHistoryBarcode = filingHistoryBarcode;
+    }
 
-	public String getEntityID() {
-		return entityID;
-	}
+    public String getEntityID() {
+        return entityID;
+    }
 
-	public void setEntityID(String entityID) {
-		this.entityID = entityID;
-	}
+    public void setEntityID(String entityID) {
+        this.entityID = entityID;
+    }
 
-	public String getItemCost() {
-		return itemCost;
-	}
+    public String getItemCost() {
+        return itemCost;
+    }
 
-	public void setItemCost(String itemCost) {
-		this.itemCost = itemCost;
-	}
+    public void setItemCost(String itemCost) {
+        this.itemCost = itemCost;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/chd/order/api/service/OrderService.java
+++ b/src/main/java/uk/gov/companieshouse/chd/order/api/service/OrderService.java
@@ -72,9 +72,15 @@ public class OrderService {
         String paymentReference = midRequest.getPaymentReference();
         String barcode = midRequest.getFilingHistoryBarcode();
         String entityId = midRequest.getEntityID();
-        String finalPaymentReference = entityId != null ? paymentReference + entityId :
-            barcode != null ? paymentReference + "--" + barcode :
-            paymentReference;
+        String finalPaymentReference;
+
+        if (entityId != null) {
+            finalPaymentReference = paymentReference + entityId;
+        } else if (barcode != null) {
+            finalPaymentReference = paymentReference + "--" + barcode;
+        } else {
+            finalPaymentReference = paymentReference;
+        }
 
         orderHeader.setNumOrderLines(NUM_ORDER_LINES);
         orderHeader.setCustomerVersion(customerVersion);

--- a/src/main/java/uk/gov/companieshouse/chd/order/api/service/OrderService.java
+++ b/src/main/java/uk/gov/companieshouse/chd/order/api/service/OrderService.java
@@ -52,6 +52,7 @@ public class OrderService {
 
     /**
      * Saves order details to CHPRD tables `ORDERHEADER` and `ORDERDETAIL` from data received in MID request.
+     *
      * @param midRequest order details to be persisted
      */
     public OrderHeader saveOrderDetails(MissingImageDeliveriesRequest midRequest) {
@@ -67,6 +68,14 @@ public class OrderService {
 
     private OrderHeader createOrderHeader(MissingImageDeliveriesRequest midRequest) {
         OrderHeader orderHeader = new OrderHeader();
+
+        String paymentReference = midRequest.getPaymentReference();
+        String barcode = midRequest.getFilingHistoryBarcode();
+        String entityId = midRequest.getEntityID();
+        String finalPaymentReference = entityId != null ? paymentReference + entityId :
+            barcode != null ? paymentReference + "--" + barcode :
+            paymentReference;
+
         orderHeader.setNumOrderLines(NUM_ORDER_LINES);
         orderHeader.setCustomerVersion(customerVersion);
         orderHeader.setCustomerId(customerId);
@@ -79,7 +88,7 @@ public class OrderService {
         orderHeader.setFlags(flags);
         orderHeader.setPaymentMethod(paymentMethod);
         orderHeader.setStatus(STATUS);
-        orderHeader.setPaymentReference(midRequest.getPaymentReference());
+        orderHeader.setPaymentReference(finalPaymentReference);
         orderHeader.setOrderDateTime(midRequest.getOrderedAt());
 
         return orderHeader;

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/controller/MissingImageDeliveriesControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/controller/MissingImageDeliveriesControllerIntegrationTest.java
@@ -48,6 +48,8 @@ class MissingImageDeliveriesControllerIntegrationTest {
         MISSING_IMAGE_DELIVERIES_DTO.setFilingHistoryCategory("Test");
         MISSING_IMAGE_DELIVERIES_DTO.setFilingHistoryDate("25-10-2018");
         MISSING_IMAGE_DELIVERIES_DTO.setFilingHistoryDescription("Test");
+        MISSING_IMAGE_DELIVERIES_DTO.setFilingHistoryBarcode("111111");
+        MISSING_IMAGE_DELIVERIES_DTO.setEntityID("222222");
         MISSING_IMAGE_DELIVERIES_DTO.setId("Test");
         MISSING_IMAGE_DELIVERIES_DTO.setItemCost("Test");
         MISSING_IMAGE_DELIVERIES_DTO.setOrderedAt(LocalDateTime.now());

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/controller/MissingImageDeliveriesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/controller/MissingImageDeliveriesControllerTest.java
@@ -49,6 +49,8 @@ class MissingImageDeliveriesControllerTest {
         MISSING_IMAGE_DELIVERIES_DTO.setFilingHistoryCategory("Test");
         MISSING_IMAGE_DELIVERIES_DTO.setFilingHistoryDate("25-10-2018");
         MISSING_IMAGE_DELIVERIES_DTO.setFilingHistoryDescription("Test");
+        MISSING_IMAGE_DELIVERIES_DTO.setFilingHistoryBarcode("111111");
+        MISSING_IMAGE_DELIVERIES_DTO.setEntityID("222222");
         MISSING_IMAGE_DELIVERIES_DTO.setId("Test");
         MISSING_IMAGE_DELIVERIES_DTO.setItemCost("Test");
         MISSING_IMAGE_DELIVERIES_DTO.setOrderedAt(LocalDateTime.now());

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/controller/MissingImageDeliveriesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/controller/MissingImageDeliveriesControllerTest.java
@@ -39,14 +39,14 @@ class MissingImageDeliveriesControllerTest {
     @Mock
     private MissingImageDeliveriesRequestMapper midRequestMapper;
 
-	@Mock
-	private MissingImageDeliveriesRequest midRequest;
+    @Mock
+    private MissingImageDeliveriesRequest midRequest;
 
-	@Mock
-	private OrderServiceException orderServiceException;
+    @Mock
+    private OrderServiceException orderServiceException;
 
-	@Mock
-	private OrderService orderService;
+    @Mock
+    private OrderService orderService;
 
     private static final MissingImageDeliveriesDTO MISSING_IMAGE_DELIVERIES_DTO;
 
@@ -69,10 +69,11 @@ class MissingImageDeliveriesControllerTest {
     @Test
     @DisplayName("Create Missing image delivery successfully")
     void createMissingImageDeliverySuccessfully() {
-        when(createMissingImageDeliveryItemRequestValidator.getValidationErrors(MISSING_IMAGE_DELIVERIES_DTO))
-            .thenReturn(new ArrayList<String>());
-        final ResponseEntity<Object> response = controllerUnderTest.createMissingImageDelivery(
-            MISSING_IMAGE_DELIVERIES_DTO, request);
+        when(createMissingImageDeliveryItemRequestValidator
+                .getValidationErrors(MISSING_IMAGE_DELIVERIES_DTO))
+                        .thenReturn(new ArrayList<String>());
+        final ResponseEntity<Object> response = controllerUnderTest
+                .createMissingImageDelivery(MISSING_IMAGE_DELIVERIES_DTO, request);
         assertThat(response.getStatusCode(), is(HttpStatus.CREATED));
     }
 
@@ -82,25 +83,27 @@ class MissingImageDeliveriesControllerTest {
         ArrayList<String> errors = new ArrayList<String>();
         String message = "company_name: must not be null or empty in create item request";
         errors.add(message);
-        when(createMissingImageDeliveryItemRequestValidator.getValidationErrors(MISSING_IMAGE_DELIVERIES_DTO))
-            .thenReturn(errors);
-        final ResponseEntity<Object> response = controllerUnderTest.createMissingImageDelivery(
-            MISSING_IMAGE_DELIVERIES_DTO, request);
+        when(createMissingImageDeliveryItemRequestValidator
+                .getValidationErrors(MISSING_IMAGE_DELIVERIES_DTO)).thenReturn(errors);
+        final ResponseEntity<Object> response = controllerUnderTest
+                .createMissingImageDelivery(MISSING_IMAGE_DELIVERIES_DTO, request);
         assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
-        assertThat(((ApiError)response.getBody()).getErrors().get(0), is(message));
+        assertThat(((ApiError) response.getBody()).getErrors().get(0), is(message));
     }
-    
-	@Test
-	@DisplayName("Test Exception on Creating MID - Unable to save Request messsage sent")
-	void createMissingImageDeliverTestExecutionException() {
-		when(createMissingImageDeliveryItemRequestValidator.getValidationErrors(MISSING_IMAGE_DELIVERIES_DTO))
-				.thenReturn(new ArrayList<String>());
-		when(midRequestMapper.mapMissingImageDeliveriesRequest(MISSING_IMAGE_DELIVERIES_DTO)).thenReturn(midRequest);
-		when(orderService.saveOrderDetails(midRequest)).thenThrow(OrderServiceException.class);
 
-		final ResponseEntity<Object> response = controllerUnderTest
-				.createMissingImageDelivery(MISSING_IMAGE_DELIVERIES_DTO, request);
+    @Test
+    @DisplayName("Test Exception on Creating MID - Unable to save Request messsage sent")
+    void createMissingImageDeliverTestExecutionException() {
+        when(createMissingImageDeliveryItemRequestValidator
+                .getValidationErrors(MISSING_IMAGE_DELIVERIES_DTO))
+                        .thenReturn(new ArrayList<String>());
+        when(midRequestMapper.mapMissingImageDeliveriesRequest(MISSING_IMAGE_DELIVERIES_DTO))
+                .thenReturn(midRequest);
+        when(orderService.saveOrderDetails(midRequest)).thenThrow(OrderServiceException.class);
 
-		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-	}
+        final ResponseEntity<Object> response = controllerUnderTest
+                .createMissingImageDelivery(MISSING_IMAGE_DELIVERIES_DTO, request);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/mapper/MissingImageDeliveriesRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/mapper/MissingImageDeliveriesRequestMapperTest.java
@@ -31,6 +31,8 @@ class MissingImageDeliveriesRequestMapperTest {
     private static final String FILING_HISTORY_CATEGORY = "officer";
     private static final String FILING_HISTORY_DATE = "2010-02-12";
     private static final String FILING_HISTORY_DESCRIPTION = "change-person-director-company-with-change-date";
+    private static final String FILING_HISTORY_BARCODE = "1111111";
+    private static final String ENTITY_ID = "222222";
 
     @Autowired
     private MissingImageDeliveriesRequestMapper mapperUnderTest;
@@ -47,6 +49,8 @@ class MissingImageDeliveriesRequestMapperTest {
         midDTO.setFilingHistoryCategory(FILING_HISTORY_CATEGORY);
         midDTO.setFilingHistoryDate(FILING_HISTORY_DATE);
         midDTO.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
+        midDTO.setFilingHistoryBarcode(FILING_HISTORY_BARCODE);
+        midDTO.setEntityID(ENTITY_ID);
 
         final MissingImageDeliveriesRequest midRequest = mapperUnderTest.mapMissingImageDeliveriesRequest(midDTO);
 
@@ -59,5 +63,7 @@ class MissingImageDeliveriesRequestMapperTest {
         assertThat(midRequest.getFilingHistoryCategory(), is(FILING_HISTORY_CATEGORY));
         assertThat(midRequest.getFilingHistoryDate(), is(FILING_HISTORY_DATE));
         assertThat(midRequest.getFilingHistoryDescription(), is(FILING_HISTORY_DESCRIPTION));
+        assertThat(midRequest.getFilingHistoryBarcode(), is(FILING_HISTORY_BARCODE));
+        assertThat(midRequest.getEntityID(), is(ENTITY_ID));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
@@ -42,14 +42,14 @@ class OrderServiceTest {
     private static final String ENTITY_ID = "222222";
     private static final String PAYMENT_REFERENCE_APPENED_BARCODE = "payment xyz--1111111";
     private static final String PAYMENT_REFERENCE_APPENED_ENTITY_ID = "payment xyz222222";
-	private static final String FH_DESCRIPTION = "memorandum-articles";
-	private static final String FH_TYPE = "MEM/ARTS";
-	private static final String ID = "MID-898216-037074";
-	private static final String COMPANY_NAME = "THE GIRLS' DAY SCHOOL TRUST";
-	private static final String COMPANY_NUMBER = "00006400";
-	private static final String PAYMENT_REF = "1234";
+    private static final String FH_DESCRIPTION = "memorandum-articles";
+    private static final String FH_TYPE = "MEM/ARTS";
+    private static final String ID = "MID-898216-037074";
+    private static final String COMPANY_NAME = "THE GIRLS' DAY SCHOOL TRUST";
+    private static final String COMPANY_NUMBER = "00006400";
+    private static final String PAYMENT_REF = "1234";
 
-	private static final String MSG_ERROR = "Unable to save Request";
+    private static final String MSG_ERROR = "Unable to save Request";
 
 
     @InjectMocks
@@ -59,25 +59,25 @@ class OrderServiceTest {
     private OrderHeaderRepository orderHeaderRepository;
 
     @Mock
-	private MissingImageDeliveriesRequest midRequest;
+    private MissingImageDeliveriesRequest midRequest;
 
-	@Mock
-	private OrderDetails orderDetails;
+    @Mock
+    private OrderDetails orderDetails;
 
-	@Mock
-	private OrderHeader orderHeaderTest;
+    @Mock
+    private OrderHeader orderHeaderTest;
 
-	@Mock
-	private DataAccessException dataAccessException;
+    @Mock
+    private DataAccessException dataAccessException;
 
-	@Mock
+    @Mock
     private OrderServiceException orderServiceException;
 
     @Captor
     ArgumentCaptor<OrderHeader> orderHeaderArgumentCaptor;
 
     @Test
-    void saveOrderDetailsPersistsOrderHeader(){
+    void saveOrderDetailsPersistsOrderHeader() {
         // given
         when(midRequest.getFilingHistoryCategory()).thenReturn(FH_CATEGORY);
         when(midRequest.getFilingHistoryDate()).thenReturn(FH_DATE);
@@ -134,28 +134,28 @@ class OrderServiceTest {
         assertEquals(PAYMENT_REFERENCE_APPENED_ENTITY_ID, orderHeaderValue.getPaymentReference());
     }
 
-	@Test
-	void saveOrderDetailsPersistsOrderHeaderTestOrderServiceException() {
-		// Given the request is Complete
-		when(midRequest.getId()).thenReturn(ID);
-		when(midRequest.getCompanyName()).thenReturn(COMPANY_NAME);
-		when(midRequest.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
-		when(midRequest.getOrderedAt()).thenReturn(LocalDateTime.now());
-		when(midRequest.getPaymentReference()).thenReturn(PAYMENT_REF);
-		when(midRequest.getFilingHistoryCategory()).thenReturn(FH_CATEGORY);
-		when(midRequest.getFilingHistoryDescription()).thenReturn(FH_DESCRIPTION);
-		when(midRequest.getFilingHistoryDate()).thenReturn(FH_DATE);
-		when(midRequest.getFilingHistoryType()).thenReturn(FH_TYPE);
-		when(midRequest.getItemCost()).thenReturn(ITEM_COST);
-		orderHeaderTest.setOrderDetails(Collections.singleton(orderDetails));
+    @Test
+    void saveOrderDetailsPersistsOrderHeaderTestOrderServiceException() {
+        // Given the request is Complete
+        when(midRequest.getId()).thenReturn(ID);
+        when(midRequest.getCompanyName()).thenReturn(COMPANY_NAME);
+        when(midRequest.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(midRequest.getOrderedAt()).thenReturn(LocalDateTime.now());
+        when(midRequest.getPaymentReference()).thenReturn(PAYMENT_REF);
+        when(midRequest.getFilingHistoryCategory()).thenReturn(FH_CATEGORY);
+        when(midRequest.getFilingHistoryDescription()).thenReturn(FH_DESCRIPTION);
+        when(midRequest.getFilingHistoryDate()).thenReturn(FH_DATE);
+        when(midRequest.getFilingHistoryType()).thenReturn(FH_TYPE);
+        when(midRequest.getItemCost()).thenReturn(ITEM_COST);
+        orderHeaderTest.setOrderDetails(Collections.singleton(orderDetails));
 
-		// When
-		doThrow(dataAccessException).when(orderHeaderRepository).save(any(OrderHeader.class));
+        // When
+        doThrow(dataAccessException).when(orderHeaderRepository).save(any(OrderHeader.class));
 
-		// Then we assert that we throw OrderServiceException inside the catch
-		// and message is set correctly
-		Exception exception = Assertions.assertThrows(OrderServiceException.class,
-				() -> serviceUnderTest.saveOrderDetails(midRequest));
-		assertTrue(exception.getMessage().contains(MSG_ERROR));
-	}
+        // Then we assert that we throw OrderServiceException inside the catch
+        // and message is set correctly
+        Exception exception = Assertions.assertThrows(OrderServiceException.class,
+                () -> serviceUnderTest.saveOrderDetails(midRequest));
+        assertTrue(exception.getMessage().contains(MSG_ERROR));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
@@ -10,6 +10,7 @@ import uk.gov.companieshouse.chd.order.api.model.OrderDetails;
 import uk.gov.companieshouse.chd.order.api.model.OrderHeader;
 import uk.gov.companieshouse.chd.order.api.repository.OrderHeaderRepository;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,6 +24,17 @@ class OrderServiceTest {
     private static final String FH_CATEGORY = "accounts";
     private static final String FH_DATE = "2018-04-22";
     private static final String ITEM_COST = "3";
+    private static final String ID = "MID-462515-995726";
+    private static final String COMPANY_NUMBER = "00006400";
+    private static final String COMPANY_NAME = "THE GIRLS' DAY SCHOOL TRUST";
+    private static final String PAYMENT_REFERENCE = "payment xyz";
+    private static final LocalDateTime ORDERED_AT = LocalDateTime.parse("2020-10-26T10:20:46.058");
+    private static final String FILING_HISTORY_CATEGORY = "officer";
+    private static final String FILING_HISTORY_DATE = "2010-02-12";
+    private static final String FILING_HISTORY_DESCRIPTION = "change-person-director-company-with-change-date";
+    private static final String FILING_HISTORY_TYPE = "Filing History Test Type";
+    private static final String FILING_HISTORY_BARCODE = "1111111";
+    private static final String ENTITY_ID = "222222";
 
     @InjectMocks
     private OrderService serviceUnderTest;
@@ -49,4 +61,5 @@ class OrderServiceTest {
         // when and then
         assertThat(serviceUnderTest.saveOrderDetails(midRequest), is(orderHeader));
     }
+
 }

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
@@ -40,8 +40,8 @@ class OrderServiceTest {
     private static final String ITEM_COST = "3";
     private static final String FILING_HISTORY_BARCODE = "1111111";
     private static final String ENTITY_ID = "222222";
-    private static final String PAYMENT_REFERENCE_APPENED_BARCODE = "payment xyz--1111111";
-    private static final String PAYMENT_REFERENCE_APPENED_ENTITY_ID = "payment xyz222222";
+    private static final String PAYMENT_REFERENCE_APPENDED_BARCODE = "payment xyz--1111111";
+    private static final String PAYMENT_REFERENCE_APPENDED_ENTITY_ID = "payment xyz222222";
     private static final String FH_DESCRIPTION = "memorandum-articles";
     private static final String FH_TYPE = "MEM/ARTS";
     private static final String ID = "MID-898216-037074";
@@ -102,7 +102,7 @@ class OrderServiceTest {
 
         OrderHeader orderHeaderValue = orderHeaderArgumentCaptor.getValue();
 
-        assertEquals(PAYMENT_REFERENCE_APPENED_BARCODE, orderHeaderValue.getPaymentReference());
+        assertEquals(PAYMENT_REFERENCE_APPENDED_BARCODE, orderHeaderValue.getPaymentReference());
     }
 
     @Test
@@ -116,7 +116,7 @@ class OrderServiceTest {
 
         OrderHeader orderHeaderValue = orderHeaderArgumentCaptor.getValue();
 
-        assertEquals(PAYMENT_REFERENCE_APPENED_ENTITY_ID, orderHeaderValue.getPaymentReference());
+        assertEquals(PAYMENT_REFERENCE_APPENDED_ENTITY_ID, orderHeaderValue.getPaymentReference());
     }
 
     @Test
@@ -131,7 +131,7 @@ class OrderServiceTest {
 
         OrderHeader orderHeaderValue = orderHeaderArgumentCaptor.getValue();
 
-        assertEquals(PAYMENT_REFERENCE_APPENED_ENTITY_ID, orderHeaderValue.getPaymentReference());
+        assertEquals(PAYMENT_REFERENCE_APPENDED_ENTITY_ID, orderHeaderValue.getPaymentReference());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
@@ -2,8 +2,11 @@ package uk.gov.companieshouse.chd.order.api.service;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.chd.order.api.model.MissingImageDeliveriesRequest;
 import uk.gov.companieshouse.chd.order.api.model.OrderDetails;
@@ -15,6 +18,7 @@ import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -35,6 +39,8 @@ class OrderServiceTest {
     private static final String FILING_HISTORY_TYPE = "Filing History Test Type";
     private static final String FILING_HISTORY_BARCODE = "1111111";
     private static final String ENTITY_ID = "222222";
+    private static final String PAYMENT_REFERENCE_APPENED_BARCODE = "payment xyz--1111111";
+    private static final String PAYMENT_REFERENCE_APPENED_ENTITY_ID = "payment xyz222222";
 
     @InjectMocks
     private OrderService serviceUnderTest;
@@ -47,6 +53,9 @@ class OrderServiceTest {
 
     @Mock
     private OrderDetails orderDetails;
+
+    @Captor
+    ArgumentCaptor<OrderHeader> orderHeaderArgumentCaptor;
 
     @Test
     void saveOrderDetailsPersistsOrderHeader(){
@@ -62,4 +71,76 @@ class OrderServiceTest {
         assertThat(serviceUnderTest.saveOrderDetails(midRequest), is(orderHeader));
     }
 
+    @Test
+    void paymentRefHasBarcodeAppended() {
+        final MissingImageDeliveriesRequest midRequest = new MissingImageDeliveriesRequest();
+        midRequest.setId(ID);
+        midRequest.setCompanyNumber(COMPANY_NUMBER);
+        midRequest.setCompanyName(COMPANY_NAME);
+        midRequest.setPaymentReference(PAYMENT_REFERENCE);
+        midRequest.setOrderedAt(ORDERED_AT);
+        midRequest.setItemCost(ITEM_COST);
+        midRequest.setFilingHistoryCategory(FILING_HISTORY_CATEGORY);
+        midRequest.setFilingHistoryDate(FILING_HISTORY_DATE);
+        midRequest.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
+        midRequest.setFilingHistoryType(FILING_HISTORY_TYPE);
+        midRequest.setFilingHistoryBarcode(FILING_HISTORY_BARCODE);
+
+        serviceUnderTest.saveOrderDetails(midRequest);
+
+        Mockito.verify(repository).save(orderHeaderArgumentCaptor.capture());
+
+        OrderHeader orderHeaderValue = orderHeaderArgumentCaptor.getValue();
+
+        assertEquals(PAYMENT_REFERENCE_APPENED_BARCODE, orderHeaderValue.getPaymentReference());
+    }
+
+    @Test
+    void paymentRefHasEntityIdAppended() {
+        final MissingImageDeliveriesRequest midRequest = new MissingImageDeliveriesRequest();
+        midRequest.setId(ID);
+        midRequest.setCompanyNumber(COMPANY_NUMBER);
+        midRequest.setCompanyName(COMPANY_NAME);
+        midRequest.setPaymentReference(PAYMENT_REFERENCE);
+        midRequest.setOrderedAt(ORDERED_AT);
+        midRequest.setItemCost(ITEM_COST);
+        midRequest.setFilingHistoryCategory(FILING_HISTORY_CATEGORY);
+        midRequest.setFilingHistoryDate(FILING_HISTORY_DATE);
+        midRequest.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
+        midRequest.setFilingHistoryType(FILING_HISTORY_TYPE);
+        midRequest.setEntityID(ENTITY_ID);
+
+        serviceUnderTest.saveOrderDetails(midRequest);
+
+        Mockito.verify(repository).save(orderHeaderArgumentCaptor.capture());
+
+        OrderHeader orderHeaderValue = orderHeaderArgumentCaptor.getValue();
+
+        assertEquals(PAYMENT_REFERENCE_APPENED_ENTITY_ID, orderHeaderValue.getPaymentReference());
+    }
+
+    @Test
+    void paymentRefHasEntityIdAppendedWhenBarcodeIsAlsoAvailable() {
+        final MissingImageDeliveriesRequest midRequest = new MissingImageDeliveriesRequest();
+        midRequest.setId(ID);
+        midRequest.setCompanyNumber(COMPANY_NUMBER);
+        midRequest.setCompanyName(COMPANY_NAME);
+        midRequest.setPaymentReference(PAYMENT_REFERENCE);
+        midRequest.setOrderedAt(ORDERED_AT);
+        midRequest.setItemCost(ITEM_COST);
+        midRequest.setFilingHistoryCategory(FILING_HISTORY_CATEGORY);
+        midRequest.setFilingHistoryDate(FILING_HISTORY_DATE);
+        midRequest.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
+        midRequest.setFilingHistoryType(FILING_HISTORY_TYPE);
+        midRequest.setFilingHistoryBarcode(FILING_HISTORY_BARCODE);
+        midRequest.setEntityID(ENTITY_ID);
+
+        serviceUnderTest.saveOrderDetails(midRequest);
+
+        Mockito.verify(repository).save(orderHeaderArgumentCaptor.capture());
+
+        OrderHeader orderHeaderValue = orderHeaderArgumentCaptor.getValue();
+
+        assertEquals(PAYMENT_REFERENCE_APPENED_ENTITY_ID, orderHeaderValue.getPaymentReference());
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/service/OrderServiceTest.java
@@ -13,7 +13,6 @@ import uk.gov.companieshouse.chd.order.api.model.OrderDetails;
 import uk.gov.companieshouse.chd.order.api.model.OrderHeader;
 import uk.gov.companieshouse.chd.order.api.repository.OrderHeaderRepository;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,21 +21,13 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.chd.order.api.testUtils.ItemSetup.setUpMissingImageDeliveriesRequest;
 
 @ExtendWith(MockitoExtension.class)
 class OrderServiceTest {
     private static final String FH_CATEGORY = "accounts";
     private static final String FH_DATE = "2018-04-22";
     private static final String ITEM_COST = "3";
-    private static final String ID = "MID-462515-995726";
-    private static final String COMPANY_NUMBER = "00006400";
-    private static final String COMPANY_NAME = "THE GIRLS' DAY SCHOOL TRUST";
-    private static final String PAYMENT_REFERENCE = "payment xyz";
-    private static final LocalDateTime ORDERED_AT = LocalDateTime.parse("2020-10-26T10:20:46.058");
-    private static final String FILING_HISTORY_CATEGORY = "officer";
-    private static final String FILING_HISTORY_DATE = "2010-02-12";
-    private static final String FILING_HISTORY_DESCRIPTION = "change-person-director-company-with-change-date";
-    private static final String FILING_HISTORY_TYPE = "Filing History Test Type";
     private static final String FILING_HISTORY_BARCODE = "1111111";
     private static final String ENTITY_ID = "222222";
     private static final String PAYMENT_REFERENCE_APPENED_BARCODE = "payment xyz--1111111";
@@ -73,17 +64,7 @@ class OrderServiceTest {
 
     @Test
     void paymentRefHasBarcodeAppended() {
-        final MissingImageDeliveriesRequest midRequest = new MissingImageDeliveriesRequest();
-        midRequest.setId(ID);
-        midRequest.setCompanyNumber(COMPANY_NUMBER);
-        midRequest.setCompanyName(COMPANY_NAME);
-        midRequest.setPaymentReference(PAYMENT_REFERENCE);
-        midRequest.setOrderedAt(ORDERED_AT);
-        midRequest.setItemCost(ITEM_COST);
-        midRequest.setFilingHistoryCategory(FILING_HISTORY_CATEGORY);
-        midRequest.setFilingHistoryDate(FILING_HISTORY_DATE);
-        midRequest.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
-        midRequest.setFilingHistoryType(FILING_HISTORY_TYPE);
+        final MissingImageDeliveriesRequest midRequest = setUpMissingImageDeliveriesRequest();
         midRequest.setFilingHistoryBarcode(FILING_HISTORY_BARCODE);
 
         serviceUnderTest.saveOrderDetails(midRequest);
@@ -97,17 +78,7 @@ class OrderServiceTest {
 
     @Test
     void paymentRefHasEntityIdAppended() {
-        final MissingImageDeliveriesRequest midRequest = new MissingImageDeliveriesRequest();
-        midRequest.setId(ID);
-        midRequest.setCompanyNumber(COMPANY_NUMBER);
-        midRequest.setCompanyName(COMPANY_NAME);
-        midRequest.setPaymentReference(PAYMENT_REFERENCE);
-        midRequest.setOrderedAt(ORDERED_AT);
-        midRequest.setItemCost(ITEM_COST);
-        midRequest.setFilingHistoryCategory(FILING_HISTORY_CATEGORY);
-        midRequest.setFilingHistoryDate(FILING_HISTORY_DATE);
-        midRequest.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
-        midRequest.setFilingHistoryType(FILING_HISTORY_TYPE);
+        final MissingImageDeliveriesRequest midRequest = setUpMissingImageDeliveriesRequest();
         midRequest.setEntityID(ENTITY_ID);
 
         serviceUnderTest.saveOrderDetails(midRequest);
@@ -121,19 +92,9 @@ class OrderServiceTest {
 
     @Test
     void paymentRefHasEntityIdAppendedWhenBarcodeIsAlsoAvailable() {
-        final MissingImageDeliveriesRequest midRequest = new MissingImageDeliveriesRequest();
-        midRequest.setId(ID);
-        midRequest.setCompanyNumber(COMPANY_NUMBER);
-        midRequest.setCompanyName(COMPANY_NAME);
-        midRequest.setPaymentReference(PAYMENT_REFERENCE);
-        midRequest.setOrderedAt(ORDERED_AT);
-        midRequest.setItemCost(ITEM_COST);
-        midRequest.setFilingHistoryCategory(FILING_HISTORY_CATEGORY);
-        midRequest.setFilingHistoryDate(FILING_HISTORY_DATE);
-        midRequest.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
-        midRequest.setFilingHistoryType(FILING_HISTORY_TYPE);
-        midRequest.setFilingHistoryBarcode(FILING_HISTORY_BARCODE);
+        final MissingImageDeliveriesRequest midRequest = setUpMissingImageDeliveriesRequest();
         midRequest.setEntityID(ENTITY_ID);
+        midRequest.setFilingHistoryBarcode(FILING_HISTORY_BARCODE);
 
         serviceUnderTest.saveOrderDetails(midRequest);
 

--- a/src/test/java/uk/gov/companieshouse/chd/order/api/testUtils/ItemSetup.java
+++ b/src/test/java/uk/gov/companieshouse/chd/order/api/testUtils/ItemSetup.java
@@ -1,23 +1,52 @@
 package uk.gov.companieshouse.chd.order.api.testUtils;
 
 import uk.gov.companieshouse.chd.order.api.dto.MissingImageDeliveriesDTO;
+import uk.gov.companieshouse.chd.order.api.model.MissingImageDeliveriesRequest;
 
 import java.time.LocalDateTime;
 
 public class ItemSetup {
 
+    private static final String ITEM_COST = "3";
+    private static final String ID = "MID-462515-995726";
+    private static final String COMPANY_NUMBER = "00006400";
+    private static final String COMPANY_NAME = "THE GIRLS' DAY SCHOOL TRUST";
+    private static final String PAYMENT_REFERENCE = "payment xyz";
+    private static final LocalDateTime ORDERED_AT = LocalDateTime.parse("2020-10-26T10:20:46.058");
+    private static final String FILING_HISTORY_CATEGORY = "officer";
+    private static final String FILING_HISTORY_DATE = "2010-02-12";
+    private static final String FILING_HISTORY_DESCRIPTION = "change-person-director-company-with-change-date";
+    private static final String FILING_HISTORY_TYPE = "Filing History Test Type";
+
     public static MissingImageDeliveriesDTO setUpMissingImageDeliveryDTO() {
         MissingImageDeliveriesDTO missingImageDeliveriesDTO = new MissingImageDeliveriesDTO();
-        missingImageDeliveriesDTO.setCompanyName("Company Name");
-        missingImageDeliveriesDTO.setCompanyNumber("123");
-        missingImageDeliveriesDTO.setFilingHistoryCategory("Category");
-        missingImageDeliveriesDTO.setFilingHistoryDate("25-10-2018");
-        missingImageDeliveriesDTO.setFilingHistoryDescription("Test");
-        missingImageDeliveriesDTO.setFilingHistoryType("filing history type");
-        missingImageDeliveriesDTO.setId("1");
-        missingImageDeliveriesDTO.setItemCost("Item cost");
+        missingImageDeliveriesDTO.setCompanyName(COMPANY_NAME);
+        missingImageDeliveriesDTO.setCompanyNumber(COMPANY_NUMBER);
+        missingImageDeliveriesDTO.setFilingHistoryCategory(FILING_HISTORY_CATEGORY);
+        missingImageDeliveriesDTO.setFilingHistoryDate(FILING_HISTORY_DATE);
+        missingImageDeliveriesDTO.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
+        missingImageDeliveriesDTO.setFilingHistoryType(FILING_HISTORY_TYPE);
+        missingImageDeliveriesDTO.setId(ID);
+        missingImageDeliveriesDTO.setItemCost(ITEM_COST);
         missingImageDeliveriesDTO.setOrderedAt(LocalDateTime.now());
-        missingImageDeliveriesDTO.setPaymentReference("Payment reference");
+        missingImageDeliveriesDTO.setPaymentReference(PAYMENT_REFERENCE);
         return missingImageDeliveriesDTO;
+    };
+
+    public static MissingImageDeliveriesRequest setUpMissingImageDeliveriesRequest() {
+        final MissingImageDeliveriesRequest midRequest = new MissingImageDeliveriesRequest();
+        midRequest.setId(ID);
+        midRequest.setCompanyNumber(COMPANY_NUMBER);
+        midRequest.setCompanyName(COMPANY_NAME);
+        midRequest.setPaymentReference(PAYMENT_REFERENCE);
+        midRequest.setOrderedAt(ORDERED_AT);
+        midRequest.setItemCost(ITEM_COST);
+        midRequest.setFilingHistoryCategory(FILING_HISTORY_CATEGORY);
+        midRequest.setFilingHistoryDate(FILING_HISTORY_DATE);
+        midRequest.setFilingHistoryDescription(FILING_HISTORY_DESCRIPTION);
+        midRequest.setFilingHistoryType(FILING_HISTORY_TYPE);
+        midRequest.setFilingHistoryBarcode(null);
+        midRequest.setEntityID(null);
+        return midRequest;
     };
 }


### PR DESCRIPTION
Checks if the mid request has an entity Id or filing history barcode and appends the correct one to the payment reference to be persisted to the order header table

Resolves: GCI-1598