### PR TITLE
Update ecsService module and fix some failing dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+        <spring-framework.version>6.2.19</spring-framework.version>
 
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <oracle.jdbc11.version>23.8.0.25.04</oracle.jdbc11.version>
 
         <spring-boot-dependencies.version>3.5.14</spring-boot-dependencies.version>
         <spring-boot-maven-plugin.version>3.5.3</spring-boot-maven-plugin.version>
-        <spring-core.version>6.2.18</spring-core.version>
         <start-class>uk.gov.companieshouse.chd.order.api.ChdOrderApiApplication</start-class>
 
         <environment-reader-library.version>3.0.5</environment-reader-library.version>
@@ -42,21 +42,20 @@
         <api-security-java.version>2.0.8</api-security-java.version>
         <commons-lang3.version>3.19.0</commons-lang3.version>
         <system-lambda-version>1.2.1</system-lambda-version>
-        <opentelemetry-version>2.21.0</opentelemetry-version>
-        <tomcat-embed-core.version>11.0.22</tomcat-embed-core.version>
-        <tomcat-embed-websocket.version>11.0.22</tomcat-embed-websocket.version>
+        <opentelemetry-version>2.29.0</opentelemetry-version>
         <kotlin-stdlib.version>2.2.21</kotlin-stdlib.version>
         <h2database.version>2.4.240</h2database.version>
-        <log4j.version>2.26.0</log4j.version>
 
         <!-- internal -->
-        <structured-logging.version>3.0.37</structured-logging.version>
-        <private-api-sdk-java.version>4.0.317</private-api-sdk-java.version>
-        <api-sdk-manager-java-library.version>3.0.11</api-sdk-manager-java-library.version>
+        <structured-logging.version>3.0.57</structured-logging.version>
+        <private-api-sdk-java.version>7.2.3</private-api-sdk-java.version>
+        <api-sdk-manager-java-library.version>3.0.28</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
 
+        <!-- CH Dependencies BOM -->
+        <ch-boms.version>0.1.15</ch-boms.version>
 
-        <fasterxml-jackson.version>2.19.2</fasterxml-jackson.version>
+        <tools-jackson.version>3.2.1</tools-jackson.version>
         <webcompere-version>2.1.8</webcompere-version>
         <!-- Docker -->
         <jib-maven-plugin.version>3.4.6</jib-maven-plugin.version>
@@ -88,32 +87,28 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Import the CH Dependency BOM to manage versions of common dependencies -->
+            <dependency>
+                <groupId>uk.gov.companieshouse</groupId>
+                <artifactId>ch-dependency-bom</artifactId>
+                <version>${ch-boms.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- spring-framework BOM to align all Spring Framework dependencies to the same version -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring-framework.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat-embed-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>${tomcat-embed-websocket.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>${log4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-to-slf4j</artifactId>
-                <version>${log4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -255,20 +250,14 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${fasterxml-jackson.version}</version>
+            <version>${tools-jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${fasterxml-jackson.version}</version>
-        </dependency>
-        <!-- CVE-2025-41242 and CVE-2025-41249 -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>${spring-core.version}</version>
+            <version>${tools-jackson.version}</version>
         </dependency>
         <!-- Pinning version to address CVE-2020-29582(5.3) in kotlin-stdlib:jar:1.9.25
     pulled transitively by opentelemetry-spring-boot-starter:jar:2.25.0 -->

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -20,7 +20,7 @@ terraform {
 
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.336"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.346"
 
   # Environmental configuration
   environment             = var.environment


### PR DESCRIPTION
Add OpenTelemetry instrumentation to chd-order-api service
Fulfils remainder of [ASM-1741](https://companieshouse.atlassian.net/browse/ASM-1741)

[ASM-1741]: https://companieshouse.atlassian.net/browse/ASM-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ